### PR TITLE
change from --frozen-lockfile to --immutable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
+      - name: Prepare Yarn 4
+        run: corepack prepare yarn@4.9.1 --activate
+
       - name: Install dependencies
         run: yarn install --immutable
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - CI updated to use Yarn 4 and enforce immutable dependency installation for more reliable, reproducible builds and faster detection of lockfile drift.
  - No user-facing changes; application behavior and release artifacts remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->