### PR TITLE
chore: enable corepack in translation workflow

### DIFF
--- a/.github/workflows/gemini-translation.yml
+++ b/.github/workflows/gemini-translation.yml
@@ -42,6 +42,10 @@ jobs:
       - name: 'Checkout repository'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8'
 
+      - name: 'Enable Corepack'
+        run: |
+          corepack enable
+
       - name: 'Set up Node.js'
         uses: 'actions/setup-node@v4'
         with:
@@ -50,7 +54,6 @@ jobs:
 
       - name: 'Install dependencies'
         run: |
-          corepack enable
           yarn install --immutable
 
       - name: 'Install Gemini CLI'


### PR DESCRIPTION
- gemini-translation ワークフローに corepack enable を追加し、Yarn 4.x を確実に利用
- actions/setup-node@v4 実行時に Yarn 1.x が選ばれてしまう問題を防止


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to enable Corepack in a dedicated step and streamlined dependency installation with immutable Yarn installs.
  * Improves reliability and consistency of build steps; no changes to application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->