### PR TITLE
fix: normalize gemini translation cli command string

### DIFF
--- a/.github/workflows/gemini-translation.yml
+++ b/.github/workflows/gemini-translation.yml
@@ -68,13 +68,7 @@ jobs:
           GOOGLE_CLOUD_LOCATION: ${{ vars.GOOGLE_CLOUD_LOCATION }}
           GEMINI_TRANSLATION_MODEL: ${{ vars.GEMINI_TRANSLATION_MODEL || 'gemini-1.5-pro' }}
           GEMINI_TRANSLATION_CLI: >-
-            ["bash","-lc","gemini text \
-              --model ${GEMINI_TRANSLATION_MODEL:-gemini-1.5-pro} \
-              --input-file {PROMPT_FILE} \
-              --output-file {OUTPUT_FILE} \
-              --use-vertex-ai=${{ vars.GOOGLE_GENAI_USE_VERTEXAI }} \
-              --project=${{ vars.GOOGLE_CLOUD_PROJECT }} \
-              --location=${{ vars.GOOGLE_CLOUD_LOCATION }}"]
+            ["bash","-lc","gemini text --model ${GEMINI_TRANSLATION_MODEL:-gemini-1.5-pro} --input-file {PROMPT_FILE} --output-file {OUTPUT_FILE} --use-vertex-ai=${{ vars.GOOGLE_GENAI_USE_VERTEXAI }} --project=${{ vars.GOOGLE_CLOUD_PROJECT }} --location=${{ vars.GOOGLE_CLOUD_LOCATION }}"]
           TRANSLATION_ALLOWED_LANGUAGES: en,ja
         run: |
           node scripts/translate-docs.mjs


### PR DESCRIPTION
- GEMINI_TRANSLATION_CLI の JSON 文字列を 1 行化し、改行エスケープによるパースエラーを解消
- ワークフロー実行時に CLI コマンドを正しく JSON.parse できるように修正


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the translation workflow command to a single-line format for improved consistency and readability in CI.
  * Reduces risk of YAML line-continuation/escaping issues and makes logs easier to scan.
  * No changes to the underlying command behavior, inputs, or outputs.
  * No user-facing impact; translation results and release processes remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->