### PR TITLE
fix: pipe prompt into gemini cli in translation workflow

### DIFF
--- a/.github/workflows/gemini-translation.yml
+++ b/.github/workflows/gemini-translation.yml
@@ -68,7 +68,7 @@ jobs:
           GOOGLE_CLOUD_LOCATION: ${{ vars.GOOGLE_CLOUD_LOCATION }}
           GEMINI_TRANSLATION_MODEL: ${{ vars.GEMINI_TRANSLATION_MODEL || 'gemini-1.5-pro' }}
           GEMINI_TRANSLATION_CLI: >-
-            ["bash","-lc","gemini text --model ${GEMINI_TRANSLATION_MODEL:-gemini-1.5-pro} --input-file {PROMPT_FILE} --output-file {OUTPUT_FILE} --use-vertex-ai=${{ vars.GOOGLE_GENAI_USE_VERTEXAI }} --project=${{ vars.GOOGLE_CLOUD_PROJECT }} --location=${{ vars.GOOGLE_CLOUD_LOCATION }}"]
+            ["bash","-lc","set -eo pipefail; cat {PROMPT_FILE} | gemini --model ${GEMINI_TRANSLATION_MODEL:-gemini-1.5-pro} --use-vertex-ai=${{ vars.GOOGLE_GENAI_USE_VERTEXAI }} --project=${{ vars.GOOGLE_CLOUD_PROJECT }} --location=${{ vars.GOOGLE_CLOUD_LOCATION }} > {OUTPUT_FILE}"]
           TRANSLATION_ALLOWED_LANGUAGES: en,ja
         run: |
           node scripts/translate-docs.mjs


### PR DESCRIPTION
- GEMINI_TRANSLATION_CLI を標準入力/出力経由の実行に変更し、未対応フラグによるエラーを回避
- set -eo pipefail を追加して CLI 実行失敗を確実に検知できるように調整
