### PR TITLE
feat: allow skipping translation workflow via label

### DIFF
--- a/.github/workflows/gemini-translation.yml
+++ b/.github/workflows/gemini-translation.yml
@@ -42,30 +42,60 @@ jobs:
       - name: 'Checkout repository'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8'
 
+      - name: 'Check skip label on associated PR'
+        id: 'check_skip_label'
+        uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea'
+        env:
+          SKIP_LABEL: '${{ vars.GEMINI_TRANSLATION_SKIP_LABEL || 'skip-translation' }}'
+        with:
+          script: |
+            const labelName = process.env.SKIP_LABEL;
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha,
+            });
+
+            const match = prs.find((pr) =>
+              pr.labels?.some((label) => label.name === labelName),
+            );
+
+            core.setOutput('skip', match ? 'true' : 'false');
+            core.setOutput('label', labelName);
+            if (match) {
+              core.info(`Found label "${labelName}" on PR #${match.number}; translation will be skipped.`);
+            }
+
       - name: 'Enable Corepack'
+        if: ${{ steps.check_skip_label.outputs.skip != 'true' }}
         run: |
           corepack enable
 
       - name: 'Set up Node.js'
+        if: ${{ steps.check_skip_label.outputs.skip != 'true' }}
         uses: 'actions/setup-node@v4'
         with:
           node-version: '20'
           cache: 'yarn'
 
       - name: 'Install dependencies'
+        if: ${{ steps.check_skip_label.outputs.skip != 'true' }}
         run: |
           yarn install --immutable
 
       - name: 'Install Gemini CLI'
+        if: ${{ steps.check_skip_label.outputs.skip != 'true' }}
         run: |
           npm install -g "@google/gemini-cli@${{ vars.GEMINI_CLI_VERSION }}"
 
       - name: 'Generate timestamp'
         id: 'timestamp'
+        if: ${{ steps.check_skip_label.outputs.skip != 'true' }}
         run: |
           echo "value=$(date -u '+%Y%m%d-%H%M%S')" >> "$GITHUB_OUTPUT"
 
       - name: 'Run Gemini translation orchestrator'
+        if: ${{ steps.check_skip_label.outputs.skip != 'true' }}
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
@@ -80,6 +110,7 @@ jobs:
 
       - name: 'Check for changes'
         id: 'git_status'
+        if: ${{ steps.check_skip_label.outputs.skip != 'true' }}
         run: |
           if [[ -z "$(git status --porcelain)" ]]; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
@@ -103,3 +134,4 @@ jobs:
             docs/
             .translations.json
             translations/targets.csv
+          labels: '${{ vars.GEMINI_TRANSLATION_SKIP_LABEL || 'skip-translation' }}'

--- a/docs/github-workflows_en.md
+++ b/docs/github-workflows_en.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This repository contains five GitHub Actions workflows that automate processes using Gemini AI.  A detailed explanation of the document translation pipeline is also provided in `docs/translation-workflow.md`.
+This repository contains five GitHub Actions workflows that automate processes using Gemini AI. A detailed explanation of the document translation pipeline is also provided in `docs/translation-workflow.md`.
 
 ## Workflow Configuration
 

--- a/docs/translation-workflow_en.md
+++ b/docs/translation-workflow_en.md
@@ -16,6 +16,7 @@ This document summarizes the behavior of the document translation pipeline, prim
 
 - Local: `yarn translate` for actual execution, `yarn translate:dry-run` to check differences only
 - CI: `.github/workflows/gemini-translation.yml` automatically runs on push to `main` and proposes translation results as a PR.
+  - The generated PR is labeled with `skip-translation` by default. When a commit associated with a PR carrying that label hits `main`, the workflow detects it and exits immediately. You can change the label via `vars.GEMINI_TRANSLATION_SKIP_LABEL`.
 
 ## Process Flow
 

--- a/docs/translation-workflow_original.md
+++ b/docs/translation-workflow_original.md
@@ -16,6 +16,7 @@
 
 - ローカル: `yarn translate` で本実行、`yarn translate:dry-run` で差分のみ確認
 - CI: `.github/workflows/gemini-translation.yml` が `main` への push で自動実行し、翻訳結果を PR として提案します。
+  - 自動生成される PR には既定で `skip-translation` ラベルが付与され、同ラベル付き PR が紐づくコミットであれば次回のワークフロー実行時に冒頭でスキップされます。ラベル名は `vars.GEMINI_TRANSLATION_SKIP_LABEL` で変更可能です。
 
 ## 処理の流れ
 


### PR DESCRIPTION
- gemini-translation.yml にスキップ判定を追加し、指定ラベル付き PR では処理を即終了
- 自動生成される PR に skip-translation ラベルを付与（vars.GEMINI_TRANSLATION_SKIP_LABEL で変更可）
- translation-workflow ドキュメントにラベル運用手順を追記
