### PR TITLE
feat: add automated documentation sync workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -53,4 +53,4 @@ jobs:
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--model claude-sonnet-4-20250514 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'

--- a/.github/workflows/claude-sync-documentation.yml
+++ b/.github/workflows/claude-sync-documentation.yml
@@ -4,12 +4,12 @@ on:
     branches:
       - 'main'
     paths:
-      - "src/**/*.ts"
-      - "scripts/**/*.ts"
-      - "package.json"
-      - "tsconfig.json"
-      - ".github/workflows/**/*.yml"
-      - ".github/workflows/**/*.yaml"
+      - 'src/**/*.ts'
+      - 'scripts/**/*.ts'
+      - 'package.json'
+      - 'tsconfig.json'
+      - '.github/workflows/**/*.yml'
+      - '.github/workflows/**/*.yaml'
   workflow_dispatch: {}
 
 concurrency:

--- a/.github/workflows/claude-sync-documentation.yml
+++ b/.github/workflows/claude-sync-documentation.yml
@@ -99,7 +99,7 @@ jobs:
             Create or update files and commit changes for a documentation update.
 
           claude_args: |
-            --allowedTools "Read,Write,Edit,Bash(git:*),Bash(yarn:*)"
+            --model claude-sonnet-4-20250514 --allowedTools "Read,Write,Edit,Bash(git:*),Bash(yarn:*)"
 
       - name: 'Check for changes'
         id: 'git_status'

--- a/.github/workflows/claude-sync-documentation.yml
+++ b/.github/workflows/claude-sync-documentation.yml
@@ -1,0 +1,131 @@
+name: Sync Documentation
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - "src/**/*.ts"
+      - "scripts/**/*.ts"
+      - "package.json"
+      - "tsconfig.json"
+      - ".github/workflows/**/*.yml"
+      - ".github/workflows/**/*.yaml"
+  workflow_dispatch: {}
+
+concurrency:
+  group: '${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: 'bash'
+
+jobs:
+  doc-sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: 'Check skip label on associated PR'
+        id: 'check_skip_label'
+        env:
+          SKIP_LABEL: "${{ vars.CLAUDE_DOC_SYNC_SKIP_LABEL || 'skip-doc-sync' }}"
+        uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea'
+        with:
+          script: |
+            const labelName = process.env.SKIP_LABEL;
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha,
+            });
+
+            const match = prs.find((pr) =>
+              pr.labels?.some((label) => label.name === labelName),
+            );
+
+            core.setOutput('skip', match ? 'true' : 'false');
+            core.setOutput('label', labelName);
+            if (match) {
+              core.info(`Found label "${labelName}" on PR #${match.number}; documentation sync will be skipped.`);
+            }
+
+      - uses: actions/checkout@v4
+        if: ${{ steps.check_skip_label.outputs.skip != 'true' }}
+        with:
+          fetch-depth: 0
+
+      - name: 'Generate timestamp'
+        id: 'timestamp'
+        if: ${{ steps.check_skip_label.outputs.skip != 'true' }}
+        run: |
+          echo "value=$(date -u '+%Y%m%d-%H%M%S')" >> "$GITHUB_OUTPUT"
+
+      - uses: anthropics/claude-code-action@v1
+        if: ${{ steps.check_skip_label.outputs.skip != 'true' }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            COMMIT SHA: ${{ github.sha }}
+
+            Main branch was updated with changes to TypeScript source code. Please:
+
+            1. Review the changes in src/, scripts/, and .github/workflows/ directories
+            2. Update CLAUDE.md if development commands or architecture changed
+            3. Update README_original.md if needed
+            4. Check if translation system changes require updates to docs/*_original.md files
+            5. Ensure any new environment variables are documented
+            6. Update package.json scripts documentation if new commands were added
+            7. Create new documentation files if needed (e.g., docs/api_original.md, docs/setup_original.md)
+
+            Focus on:
+            - Translation workflow documentation (original files only)
+            - Development setup instructions
+            - GitHub Actions workflow changes
+            - API changes in the translation system
+            - Configuration options and environment variables
+            - New features that need documentation
+
+            Guidelines:
+            - Only update or create original (*_original) documentation files
+            - Suggest creating new docs files for major new features
+            - Consider docs/troubleshooting_original.md for common issues
+            - Consider docs/contributing_original.md for development guidelines
+            - Translated versions will be handled by the translation workflow
+
+            Create or update files and commit changes for a documentation update.
+
+          claude_args: |
+            --allowedTools "Read,Write,Edit,Bash(git:*),Bash(yarn:*)"
+
+      - name: 'Check for changes'
+        id: 'git_status'
+        if: ${{ steps.check_skip_label.outputs.skip != 'true' }}
+        run: |
+          if [[ -z "$(git status --porcelain)" ]]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: 'Create documentation sync pull request'
+        if: ${{ steps.git_status.outputs.has_changes == 'true' }}
+        uses: 'peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e'
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          branch: 'automation/doc-sync-${{ steps.timestamp.outputs.value }}'
+          base: 'main'
+          title: 'docs: sync documentation with code changes'
+          commit-message: 'docs: sync documentation with code changes'
+          body: |
+            Automated documentation sync triggered by changes in main branch.
+
+            Updates original documentation files to reflect code changes.
+          add-paths: |
+            CLAUDE.md
+            README_original.md
+            docs/*_original.md
+          labels: "${{ vars.CLAUDE_DOC_SYNC_SKIP_LABEL || 'skip-doc-sync' }}"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,4 +46,4 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
-          # claude_args: '--model claude-opus-4-1-20250805 --allowed-tools Bash(gh pr:*)'
+          claude_args: '--model claude-sonnet-4-20250514'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,25 +4,43 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository Overview
 
-This is a minimal repository for "Generative AI Practice" with just a basic README and MIT license. The repository appears to be in its initial state with no source code, build tools, or project structure yet established.
+This is a TypeScript/JavaScript repository for "Generative AI Practice" with documentation translation capabilities. The project includes a translation workflow system that can automatically translate Markdown documentation between languages using Gemini AI.
 
-## Current State
+## Development Commands
 
-- Repository name: `public`
-- License: MIT License (Copyright 2025 Generative AI Practice)
-- Current status: Empty repository with only README.md and LICENSE files
-- No package.json, build tools, or source code present
-- Git repository is initialized with a single initial commit
+Essential commands for development:
 
-## Development Setup
+```bash
+# Code quality and formatting
+yarn lint                    # Run ESLint on src/**/*.{js,jsx,ts,tsx}
+yarn lint:fix               # Run ESLint with --fix flag
+yarn format                 # Format code using Prettier
+yarn format:check           # Check code formatting without changes
+yarn typecheck              # Run TypeScript type checking
 
-Since this is a minimal repository without any established tooling or build system, there are no specific commands to document at this time. Future development will need to establish:
+# Translation workflow
+yarn translate              # Run the translation system
+yarn translate:dry-run      # Preview what would be translated without making changes
+```
 
-- Project structure and source code organization
-- Build and development tools
-- Testing framework
-- Linting and code quality tools
+## Translation System Architecture
 
-## Architecture
+The main feature is an automated documentation translation system (`scripts/translate-docs.ts`) that:
 
-No established architecture yet - this repository is ready for initial project setup and development.
+- Reads translation targets from `translations/targets.csv`
+- Uses segment-based translation with content hashing for efficiency
+- Stores translation metadata in `.translations.json` for incremental updates
+- Integrates with Gemini AI CLI for translations
+- Supports multiple target languages with reuse of existing translations
+
+Key configuration:
+- Translation targets: `translations/targets.csv` (CSV with relative_path, src_lang, target_langs)
+- Translation metadata: `.translations.json` (tracks hashes and translations)
+- Allowed languages: `TRANSLATION_ALLOWED_LANGUAGES` env var (default: "en,ja")
+- Translation command: `GEMINI_TRANSLATION_CLI` env var (default uses gemini CLI)
+
+The system intelligently handles:
+- Full file translation for new documents
+- Segment-level updates for modified content
+- Translation reuse based on content hashes
+- Multi-paragraph document structure preservation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,12 +34,14 @@ The main feature is an automated documentation translation system (`scripts/tran
 - Supports multiple target languages with reuse of existing translations
 
 Key configuration:
+
 - Translation targets: `translations/targets.csv` (CSV with relative_path, src_lang, target_langs)
 - Translation metadata: `.translations.json` (tracks hashes and translations)
 - Allowed languages: `TRANSLATION_ALLOWED_LANGUAGES` env var (default: "en,ja")
 - Translation command: `GEMINI_TRANSLATION_CLI` env var (default uses gemini CLI)
 
 The system intelligently handles:
+
 - Full file translation for new documents
 - Segment-level updates for modified content
 - Translation reuse based on content hashes


### PR DESCRIPTION
 - Add GitHub Actions workflow to sync documentation with code changes
  - Triggers on push to main branch for TypeScript and config files
  - Creates separate PR for documentation updates to avoid merge loops
  - Includes skip label functionality (skip-doc-sync) to prevent infinite loops
  - Supports both updating existing docs and creating new documentation files
  - Focuses on original (*_original) files only, translations handled separately
  - Integrates with existing translation workflow pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a “Sync Documentation” GitHub Actions workflow that runs on main pushes (selected paths) and manual triggers.
  * Automatically generates doc update PRs when changes are detected, with timestamped branches and labels, and supports skipping via label.

* **Documentation**
  * Overhauled CLAUDE.md with details on the translation system, supported languages, environment variables, and development commands.
  * Documented workflows for full-file and incremental translations, reuse via content hashes, and tooling setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->