### PR TITLE
Rename GitHub Actions workflow name to Claude Sync Documentation

### DIFF
--- a/.github/workflows/claude-sync-documentation.yml
+++ b/.github/workflows/claude-sync-documentation.yml
@@ -1,4 +1,4 @@
-name: Sync Documentation
+name: Claude Sync Documentation
 on:
   pull_request:
     types: [opened, synchronize]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed the internal documentation sync workflow to “Claude Sync Documentation” for clearer identification in CI.
  * No changes to triggers, paths, or execution steps; behavior remains the same.
  * No impact on application features, UI, performance, or user workflows.
  * No documentation content updates included.
  * This is a housekeeping change only; end users do not need to take any action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->