### PR TITLE
Remove three env vars from Gemini documentation sync workflow step

### DIFF
--- a/.github/workflows/gemini-sync-documentation.yml
+++ b/.github/workflows/gemini-sync-documentation.yml
@@ -98,9 +98,6 @@ jobs:
         if: ${{ steps.check_skip_label.outputs.skip != 'true' }}
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-          GOOGLE_CLOUD_PROJECT: ${{ vars.GOOGLE_CLOUD_PROJECT }}
-          GOOGLE_CLOUD_LOCATION: ${{ vars.GOOGLE_CLOUD_LOCATION }}
           GEMINI_MODEL: ${{ vars.GEMINI_DOC_SYNC_MODEL || 'gemini-1.5-pro' }}
         run: |
           # Create structured prompt file


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the Gemini documentation sync workflow by removing GOOGLE_API_KEY, GOOGLE_CLOUD_PROJECT, and GOOGLE_CLOUD_LOCATION environment variables from the execution step.
  * Reduced external configuration requirements for the documentation sync process.
  * No changes to user-facing functionality or public interfaces.
  * Routine maintenance to keep automation lightweight and consistent across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->