### PR TITLE
Add sync workflow for agent guides

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,4 +46,9 @@ jobs:
         run: yarn sync:agents
 
       - name: Ensure agent guides are synchronized
-        run: git diff --exit-code CLAUDE.md AGENTS.md
+        run: |
+          if ! git diff --exit-code CLAUDE.md AGENTS.md; then
+            echo "❌ CLAUDE.md and AGENTS.md are not synchronized. Run 'yarn sync:agents' to fix."
+            exit 1
+          fi
+          echo "✅ Agent guides are synchronized"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,9 @@ jobs:
 
       - name: Check Prettier formatting
         run: yarn format:check
+
+      - name: Synchronize agent guides
+        run: yarn sync:agents
+
+      - name: Ensure agent guides are synchronized
+        run: git diff --exit-code CLAUDE.md AGENTS.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,4 +51,9 @@ jobs:
             git diff CLAUDE.md AGENTS.md
             exit 1
           fi
+          if ! git diff --exit-code; then
+            echo "❌ Unexpected changes detected after running yarn sync:agents."
+            git status --short
+            exit 1
+          fi
           echo "✅ Agent guides are synchronized"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,13 +42,13 @@ jobs:
       - name: Check Prettier formatting
         run: yarn format:check
 
-      - name: Synchronize agent guides
-        run: yarn sync:agents
-
       - name: Ensure agent guides are synchronized
         run: |
+          yarn sync:agents
           if ! git diff --exit-code CLAUDE.md AGENTS.md; then
-            echo "❌ CLAUDE.md and AGENTS.md are not synchronized. Run 'yarn sync:agents' to fix."
+            echo "❌ CLAUDE.md and AGENTS.md are not synchronized."
+            echo "Run 'yarn sync:agents' and commit the changes."
+            git diff CLAUDE.md AGENTS.md
             exit 1
           fi
           echo "✅ Agent guides are synchronized"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository Overview
+
+This is a TypeScript/JavaScript repository for "Generative AI Practice" with documentation translation capabilities. The project includes a translation workflow system that can automatically translate Markdown documentation between languages using Gemini AI.
+
+## Development Commands
+
+Essential commands for development:
+
+```bash
+# Code quality and formatting
+yarn lint                    # Run ESLint on src/**/*.{js,jsx,ts,tsx}
+yarn lint:fix               # Run ESLint with --fix flag
+yarn format                 # Format code using Prettier
+yarn format:check           # Check code formatting without changes
+yarn typecheck              # Run TypeScript type checking
+
+# Translation workflow
+yarn translate              # Run the translation system
+yarn translate:dry-run      # Preview what would be translated without making changes
+```
+
+## Translation System Architecture
+
+The main feature is an automated documentation translation system (`scripts/translate-docs.ts`) that:
+
+- Reads translation targets from `translations/targets.csv`
+- Uses segment-based translation with content hashing for efficiency
+- Stores translation metadata in `.translations.json` for incremental updates
+- Integrates with Gemini AI CLI for translations
+- Supports multiple target languages with reuse of existing translations
+
+Key configuration:
+
+- Translation targets: `translations/targets.csv` (CSV with relative_path, src_lang, target_langs)
+- Translation metadata: `.translations.json` (tracks hashes and translations)
+- Allowed languages: `TRANSLATION_ALLOWED_LANGUAGES` env var (default: "en,ja")
+- Translation command: `GEMINI_TRANSLATION_CLI` env var (default uses gemini CLI)
+
+The system intelligently handles:
+
+- Full file translation for new documents
+- Segment-level updates for modified content
+- Translation reuse based on content hashes
+- Multi-paragraph document structure preservation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,48 +1,56 @@
-# CLAUDE.md
+# Agent Guide
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This guide summarizes the shared context and expectations for AI coding partners such as Claude Code, GitHub Copilot / Codex, and Gemini Code Assist when working in this repository. Treat the instructions below as canonical regardless of which model is active.
 
 ## Repository Overview
 
-This is a TypeScript/JavaScript repository for "Generative AI Practice" with documentation translation capabilities. The project includes a translation workflow system that can automatically translate Markdown documentation between languages using Gemini AI.
+This project is a TypeScript/JavaScript monorepo for "Generative AI Practice". It contains:
 
-## Development Commands
+- Application code under `src/` and accompanying documentation in `docs/`
+- A translation workflow that keeps `README_original.md` and localized copies like `README_en.md` in sync
+- Automation scripts in `scripts/` to assist with translation, guide synchronization, and other maintenance tasks
 
-Essential commands for development:
+## Core Development Commands
+
+Use the Yarn scripts to maintain consistent tooling across agents:
 
 ```bash
 # Code quality and formatting
-yarn lint                    # Run ESLint on src/**/*.{js,jsx,ts,tsx}
-yarn lint:fix               # Run ESLint with --fix flag
-yarn format                 # Format code using Prettier
-yarn format:check           # Check code formatting without changes
-yarn typecheck              # Run TypeScript type checking
+yarn lint              # Run ESLint on src/**/*.{js,jsx,ts,tsx}
+yarn lint:fix          # Run ESLint with automatic fixes
+yarn format            # Format code using Prettier
+yarn format:check      # Verify formatting without modifying files
+yarn typecheck         # Run the TypeScript compiler in type-check mode
+
+yarn test              # (If available) execute unit or integration tests
 
 # Translation workflow
-yarn translate              # Run the translation system
-yarn translate:dry-run      # Preview what would be translated without making changes
+yarn translate         # Run the documentation translation pipeline
+yarn translate:dry-run # Preview translation changes without writing files
+
+# Agent guide synchronization
+yarn sync:agents       # Mirror CLAUDE.md content into AGENTS.md
 ```
 
-## Translation System Architecture
+Always run `yarn sync:agents` after updating this guide so both files stay identical. CI will fail if `CLAUDE.md` and `AGENTS.md` diverge.
 
-The main feature is an automated documentation translation system (`scripts/translate-docs.ts`) that:
+## Translation System Snapshot
 
-- Reads translation targets from `translations/targets.csv`
-- Uses segment-based translation with content hashing for efficiency
-- Stores translation metadata in `.translations.json` for incremental updates
-- Integrates with Gemini AI CLI for translations
-- Supports multiple target languages with reuse of existing translations
+The translation pipeline (`scripts/translate-docs.ts`) performs segment-based Markdown translation with Gemini AI. Important pieces:
 
-Key configuration:
+- Targets are declared in `translations/targets.csv` (columns: `relative_path`, `src_lang`, `target_langs`).
+- Translation metadata lives in `.translations.json`, enabling incremental updates.
+- Allowed languages are controlled via the `TRANSLATION_ALLOWED_LANGUAGES` environment variable (default: `en,ja`).
+- Gemini CLI invocation can be overridden with `GEMINI_TRANSLATION_CLI`.
 
-- Translation targets: `translations/targets.csv` (CSV with relative_path, src_lang, target_langs)
-- Translation metadata: `.translations.json` (tracks hashes and translations)
-- Allowed languages: `TRANSLATION_ALLOWED_LANGUAGES` env var (default: "en,ja")
-- Translation command: `GEMINI_TRANSLATION_CLI` env var (default uses gemini CLI)
+The script intelligently skips already translated segments, reuses hashes, and preserves paragraph structure. Review translation diffs carefully before committing.
 
-The system intelligently handles:
+## Collaboration Tips for All Agents
 
-- Full file translation for new documents
-- Segment-level updates for modified content
-- Translation reuse based on content hashes
-- Multi-paragraph document structure preservation
+- Prefer clear, incremental commits and keep TypeScript types accurate.
+- Update or add tests when changing behavior; surface the exact command run in the final report.
+- When modifying documentation, ensure localized copies stay consistent using the translation workflow.
+- Respect existing coding conventions—no implicit any, no unused variables, and follow Prettier/ESLint defaults.
+- Surface limitations explicitly if a task cannot be completed due to environment constraints.
+
+Following these shared practices ensures a consistent experience no matter which assistant is participating in the development loop.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,48 +1,56 @@
-# CLAUDE.md
+# Agent Guide
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This guide summarizes the shared context and expectations for AI coding partners such as Claude Code, GitHub Copilot / Codex, and Gemini Code Assist when working in this repository. Treat the instructions below as canonical regardless of which model is active.
 
 ## Repository Overview
 
-This is a TypeScript/JavaScript repository for "Generative AI Practice" with documentation translation capabilities. The project includes a translation workflow system that can automatically translate Markdown documentation between languages using Gemini AI.
+This project is a TypeScript/JavaScript monorepo for "Generative AI Practice". It contains:
 
-## Development Commands
+- Application code under `src/` and accompanying documentation in `docs/`
+- A translation workflow that keeps `README_original.md` and localized copies like `README_en.md` in sync
+- Automation scripts in `scripts/` to assist with translation, guide synchronization, and other maintenance tasks
 
-Essential commands for development:
+## Core Development Commands
+
+Use the Yarn scripts to maintain consistent tooling across agents:
 
 ```bash
 # Code quality and formatting
-yarn lint                    # Run ESLint on src/**/*.{js,jsx,ts,tsx}
-yarn lint:fix               # Run ESLint with --fix flag
-yarn format                 # Format code using Prettier
-yarn format:check           # Check code formatting without changes
-yarn typecheck              # Run TypeScript type checking
+yarn lint              # Run ESLint on src/**/*.{js,jsx,ts,tsx}
+yarn lint:fix          # Run ESLint with automatic fixes
+yarn format            # Format code using Prettier
+yarn format:check      # Verify formatting without modifying files
+yarn typecheck         # Run the TypeScript compiler in type-check mode
+
+yarn test              # (If available) execute unit or integration tests
 
 # Translation workflow
-yarn translate              # Run the translation system
-yarn translate:dry-run      # Preview what would be translated without making changes
+yarn translate         # Run the documentation translation pipeline
+yarn translate:dry-run # Preview translation changes without writing files
+
+# Agent guide synchronization
+yarn sync:agents       # Mirror CLAUDE.md content into AGENTS.md
 ```
 
-## Translation System Architecture
+Always run `yarn sync:agents` after updating this guide so both files stay identical. CI will fail if `CLAUDE.md` and `AGENTS.md` diverge.
 
-The main feature is an automated documentation translation system (`scripts/translate-docs.ts`) that:
+## Translation System Snapshot
 
-- Reads translation targets from `translations/targets.csv`
-- Uses segment-based translation with content hashing for efficiency
-- Stores translation metadata in `.translations.json` for incremental updates
-- Integrates with Gemini AI CLI for translations
-- Supports multiple target languages with reuse of existing translations
+The translation pipeline (`scripts/translate-docs.ts`) performs segment-based Markdown translation with Gemini AI. Important pieces:
 
-Key configuration:
+- Targets are declared in `translations/targets.csv` (columns: `relative_path`, `src_lang`, `target_langs`).
+- Translation metadata lives in `.translations.json`, enabling incremental updates.
+- Allowed languages are controlled via the `TRANSLATION_ALLOWED_LANGUAGES` environment variable (default: `en,ja`).
+- Gemini CLI invocation can be overridden with `GEMINI_TRANSLATION_CLI`.
 
-- Translation targets: `translations/targets.csv` (CSV with relative_path, src_lang, target_langs)
-- Translation metadata: `.translations.json` (tracks hashes and translations)
-- Allowed languages: `TRANSLATION_ALLOWED_LANGUAGES` env var (default: "en,ja")
-- Translation command: `GEMINI_TRANSLATION_CLI` env var (default uses gemini CLI)
+The script intelligently skips already translated segments, reuses hashes, and preserves paragraph structure. Review translation diffs carefully before committing.
 
-The system intelligently handles:
+## Collaboration Tips for All Agents
 
-- Full file translation for new documents
-- Segment-level updates for modified content
-- Translation reuse based on content hashes
-- Multi-paragraph document structure preservation
+- Prefer clear, incremental commits and keep TypeScript types accurate.
+- Update or add tests when changing behavior; surface the exact command run in the final report.
+- When modifying documentation, ensure localized copies stay consistent using the translation workflow.
+- Respect existing coding conventions—no implicit any, no unused variables, and follow Prettier/ESLint defaults.
+- Surface limitations explicitly if a task cannot be completed due to environment constraints.
+
+Following these shared practices ensures a consistent experience no matter which assistant is participating in the development loop.

--- a/docs/github-workflows_en.md
+++ b/docs/github-workflows_en.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This repository contains five GitHub Actions workflows that automate processes using Gemini AI. A detailed explanation of the document translation pipeline is also provided in `docs/translation-workflow.md`. The CI pipeline additionally checks that the agent guides (`CLAUDE.md` and `AGENTS.md`) remain synchronized.
+This repository contains five GitHub Actions workflows that automate processes using Gemini AI. A detailed explanation of the document translation pipeline is also provided in `docs/translation-workflow.md`.
 
 ## Workflow Configuration
 
@@ -81,22 +81,6 @@ Uses the GitHub MCP server to perform PR operations:
 
 - Automatically runs at the configured time
 - Periodically triages unhandled issues
-
-### 6. ✅ Agent Guide Sync Check (step in `ci.yml`)
-
-**Ensures `CLAUDE.md` and `AGENTS.md` stay in sync**
-
-#### Role
-
-- Runs `yarn sync:agents` to detect missed local synchronizations
-- Uses `git diff --exit-code CLAUDE.md AGENTS.md` to verify both files match and fails the job if they do not
-- Outputs a clear failure message instructing contributors to run `yarn sync:agents`
-
-#### Background
-
-- `CLAUDE.md` serves as the canonical source; developers run `yarn sync:agents` locally to copy it into `AGENTS.md`
-- When only one of the files is edited, the CI check immediately flags the drift
-- After updating `CLAUDE.md`, always run `yarn sync:agents` and commit both files together
 
 ## Authentication and Configuration
 

--- a/docs/github-workflows_en.md
+++ b/docs/github-workflows_en.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This repository contains five GitHub Actions workflows that automate processes using Gemini AI. A detailed explanation of the document translation pipeline is also provided in `docs/translation-workflow.md`.
+This repository contains five GitHub Actions workflows that automate processes using Gemini AI. A detailed explanation of the document translation pipeline is also provided in `docs/translation-workflow.md`. The CI pipeline additionally checks that the agent guides (`CLAUDE.md` and `AGENTS.md`) remain synchronized.
 
 ## Workflow Configuration
 
@@ -81,6 +81,22 @@ Uses the GitHub MCP server to perform PR operations:
 
 - Automatically runs at the configured time
 - Periodically triages unhandled issues
+
+### 6. ✅ Agent Guide Sync Check (step in `ci.yml`)
+
+**Ensures `CLAUDE.md` and `AGENTS.md` stay in sync**
+
+#### Role
+
+- Runs `yarn sync:agents` to detect missed local synchronizations
+- Uses `git diff --exit-code CLAUDE.md AGENTS.md` to verify both files match and fails the job if they do not
+- Outputs a clear failure message instructing contributors to run `yarn sync:agents`
+
+#### Background
+
+- `CLAUDE.md` serves as the canonical source; developers run `yarn sync:agents` locally to copy it into `AGENTS.md`
+- When only one of the files is edited, the CI check immediately flags the drift
+- After updating `CLAUDE.md`, always run `yarn sync:agents` and commit both files together
 
 ## Authentication and Configuration
 

--- a/docs/github-workflows_original.md
+++ b/docs/github-workflows_original.md
@@ -2,7 +2,7 @@
 
 ## 概要
 
-このリポジトリには5つのGitHub Actions ワークフローがあり、Gemini AI を使った自動化処理を行います。併せて、ドキュメント翻訳パイプラインについては `docs/translation-workflow.md` に詳細な説明をまとめています。
+このリポジトリには5つのGitHub Actions ワークフローがあり、Gemini AI を使った自動化処理を行います。併せて、ドキュメント翻訳パイプラインについては `docs/translation-workflow.md` に詳細な説明をまとめています。さらに、エージェント向けドキュメント（`CLAUDE.md` と `AGENTS.md`）の同期をCIで検証するステップも導入されています。
 
 ## ワークフロー構成
 
@@ -81,6 +81,22 @@ GitHub MCP サーバーを使用してPR操作を実行：
 
 - 設定された時間に自動実行
 - 未対応の Issue を定期的にトリアージ
+
+### 6. ✅ Agent Guide Sync Check（`ci.yml` 内ステップ）
+
+**CLAUDE.md と AGENTS.md の同期検証**
+
+#### 役割
+
+- `yarn sync:agents` を実行してローカルでの同期漏れを検出
+- `git diff --exit-code CLAUDE.md AGENTS.md` で両ファイルの差分を確認し、同期されていなければジョブを失敗させる
+- 失敗時には「`yarn sync:agents` を実行して同期してほしい」という明示的なエラーメッセージを出力
+
+#### 背景
+
+- `CLAUDE.md` を正とし、ローカルで `yarn sync:agents` を実行することで `AGENTS.md` に内容をコピーする運用
+- どちらか一方だけを編集したままコミット・PRすると、CI で差分が検出されるため早期に気付ける
+- 開発者は `CLAUDE.md` を更新した後に `yarn sync:agents` を忘れず実行し、両ファイルを同一コミットで更新する
 
 ## 認証と設定
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "typecheck": "tsc --noEmit",
+    "sync:agents": "tsx scripts/sync-agent-guides.ts",
     "translate": "tsx scripts/translate-docs.ts",
     "translate:dry-run": "tsx scripts/translate-docs.ts --dry-run",
     "process-gemini-docs": "tsx scripts/process-gemini-docs.ts"

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
     "lint:fix": "eslint \"src/**/*.{js,jsx,ts,tsx}\" --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "typecheck": "tsc --noEmit",
-    "sync:agents": "tsx scripts/sync-agent-guides.ts",
-    "translate": "tsx scripts/translate-docs.ts",
-    "translate:dry-run": "tsx scripts/translate-docs.ts --dry-run",
-    "process-gemini-docs": "tsx scripts/process-gemini-docs.ts"
+    "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.scripts.json",
+    "sync:agents": "tsx --tsconfig tsconfig.scripts.json scripts/sync-agent-guides.ts",
+    "translate": "tsx --tsconfig tsconfig.scripts.json scripts/translate-docs.ts",
+    "translate:dry-run": "tsx --tsconfig tsconfig.scripts.json scripts/translate-docs.ts --dry-run",
+    "process-gemini-docs": "tsx --tsconfig tsconfig.scripts.json scripts/process-gemini-docs.ts"
   },
   "devDependencies": {
     "@eslint/js": "^9.35.0",

--- a/scripts/sync-agent-guides.ts
+++ b/scripts/sync-agent-guides.ts
@@ -12,6 +12,18 @@ function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
 async function syncAgentGuides(): Promise<void> {
   await access(claudePath);
   const content = await readFile(claudePath, 'utf8');
+  try {
+    const existingContent = await readFile(agentsPath, 'utf8');
+    if (existingContent === content) {
+      console.log('[sync-agent-guides] AGENTS.md is already up to date');
+      return;
+    }
+  } catch (error: unknown) {
+    if (!isErrnoException(error) || error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
   await writeFile(agentsPath, content, 'utf8');
   console.log('[sync-agent-guides] Synchronized AGENTS.md with CLAUDE.md');
 }

--- a/scripts/sync-agent-guides.ts
+++ b/scripts/sync-agent-guides.ts
@@ -15,7 +15,7 @@ async function syncAgentGuides(): Promise<void> {
   try {
     const existingContent = await readFile(agentsPath, 'utf8');
     if (existingContent === content) {
-      console.log('[sync-agent-guides] AGENTS.md is already up to date');
+      console.log('[sync-agent-guides] AGENTS.md already matches CLAUDE.md; no changes written');
       return;
     }
   } catch (error: unknown) {
@@ -25,7 +25,7 @@ async function syncAgentGuides(): Promise<void> {
   }
 
   await writeFile(agentsPath, content, 'utf8');
-  console.log('[sync-agent-guides] Synchronized AGENTS.md with CLAUDE.md');
+  console.log('[sync-agent-guides] Updated AGENTS.md with the latest CLAUDE.md content');
 }
 
 syncAgentGuides().catch((error: unknown) => {

--- a/scripts/sync-agent-guides.ts
+++ b/scripts/sync-agent-guides.ts
@@ -15,7 +15,9 @@ async function syncAgentGuides(): Promise<void> {
   try {
     const existingContent = await readFile(agentsPath, 'utf8');
     if (existingContent === content) {
-      console.log('[sync-agent-guides] AGENTS.md already matches CLAUDE.md; no changes written');
+      console.log(
+        '[sync-agent-guides] AGENTS.md already matches CLAUDE.md; no changes written'
+      );
       return;
     }
   } catch (error: unknown) {
@@ -25,7 +27,9 @@ async function syncAgentGuides(): Promise<void> {
   }
 
   await writeFile(agentsPath, content, 'utf8');
-  console.log('[sync-agent-guides] Updated AGENTS.md with the latest CLAUDE.md content');
+  console.log(
+    '[sync-agent-guides] Updated AGENTS.md with the latest CLAUDE.md content'
+  );
 }
 
 syncAgentGuides().catch((error: unknown) => {

--- a/scripts/sync-agent-guides.ts
+++ b/scripts/sync-agent-guides.ts
@@ -1,0 +1,20 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+const claudePath = path.join(repoRoot, 'CLAUDE.md');
+const agentsPath = path.join(repoRoot, 'AGENTS.md');
+
+void (async () => {
+  try {
+    const content = await readFile(claudePath, 'utf8');
+    await writeFile(agentsPath, content, 'utf8');
+    console.log('[sync-agent-guides] Synchronized AGENTS.md with CLAUDE.md');
+  } catch (error) {
+    console.error('[sync-agent-guides] Failed to synchronize guides.');
+    if (error instanceof Error) {
+      console.error(error.message);
+    }
+    process.exitCode = 1;
+  }
+})();

--- a/scripts/sync-agent-guides.ts
+++ b/scripts/sync-agent-guides.ts
@@ -1,20 +1,28 @@
-import { readFile, writeFile } from 'node:fs/promises';
+import { access, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 const repoRoot = process.cwd();
 const claudePath = path.join(repoRoot, 'CLAUDE.md');
 const agentsPath = path.join(repoRoot, 'AGENTS.md');
 
-void (async () => {
-  try {
-    const content = await readFile(claudePath, 'utf8');
-    await writeFile(agentsPath, content, 'utf8');
-    console.log('[sync-agent-guides] Synchronized AGENTS.md with CLAUDE.md');
-  } catch (error) {
-    console.error('[sync-agent-guides] Failed to synchronize guides.');
-    if (error instanceof Error) {
-      console.error(error.message);
-    }
-    process.exitCode = 1;
+function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error;
+}
+
+async function syncAgentGuides(): Promise<void> {
+  await access(claudePath);
+  const content = await readFile(claudePath, 'utf8');
+  await writeFile(agentsPath, content, 'utf8');
+  console.log('[sync-agent-guides] Synchronized AGENTS.md with CLAUDE.md');
+}
+
+syncAgentGuides().catch((error: unknown) => {
+  if (isErrnoException(error) && error.code === 'ENOENT') {
+    console.error(`[sync-agent-guides] Source file not found: ${claudePath}`);
+  } else if (error instanceof Error) {
+    console.error(`[sync-agent-guides] Unexpected error: ${error.message}`);
+  } else {
+    console.error('[sync-agent-guides] Unexpected unknown error');
   }
-})();
+  process.exitCode = 1;
+});

--- a/scripts/sync-agent-guides.ts
+++ b/scripts/sync-agent-guides.ts
@@ -45,9 +45,13 @@ async function syncAgentGuides(): Promise<void> {
 
 syncAgentGuides().catch((error: unknown) => {
   if (error instanceof Error) {
-    console.error(`[sync-agent-guides] Failed to synchronize guides: ${error.message}`);
+    console.error(
+      `[sync-agent-guides] Failed to synchronize guides: ${error.message}`
+    );
   } else {
-    console.error('[sync-agent-guides] Failed to synchronize guides due to an unknown error');
+    console.error(
+      '[sync-agent-guides] Failed to synchronize guides due to an unknown error'
+    );
   }
   process.exitCode = process.exitCode ?? 1;
 });

--- a/scripts/translate-docs.ts
+++ b/scripts/translate-docs.ts
@@ -65,8 +65,8 @@ const metadataPath = resolvePath(
 const allowedLanguages = new Set(
   (process.env.TRANSLATION_ALLOWED_LANGUAGES ?? 'en,ja')
     .split(',')
-    .map((value) => value.trim())
-    .filter((value) => value.length > 0)
+    .map((value: string) => value.trim())
+    .filter((value: string) => value.length > 0)
 );
 const dryRun = process.argv.includes('--dry-run');
 const defaultTranslationCommand = JSON.stringify([
@@ -701,7 +701,7 @@ async function execute(command: string, args: string[]): Promise<void> {
       env: process.env,
     });
     child.on('error', reject);
-    child.on('close', (code) => {
+    child.on('close', (code: number | null) => {
       if (code === 0) {
         resolve();
       } else {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "rootDir": "."
   },
   "include": ["src/**/*", "scripts/**/*", "types/**/*"],
   "exclude": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,11 @@
     "outDir": "dist"
   },
   "include": ["src/**/*", "scripts/**/*", "types/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "scripts/**/__tests__/**/*",
+    "scripts/**/__mocks__/**/*",
+    "scripts/**/__fixtures__/**/*"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,9 +9,8 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
-    "outDir": "dist",
-    "rootDir": "src"
+    "outDir": "dist"
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "scripts/**/*", "types/**/*"],
   "exclude": ["node_modules", "dist"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,23 +1,10 @@
 {
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["ES2020", "DOM"],
-    "module": "ESNext",
-    "moduleResolution": "node",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "declaration": true,
+    "rootDir": "src",
     "outDir": "dist",
-    "rootDir": "."
+    "declaration": true
   },
-  "include": ["src/**/*", "scripts/**/*", "types/**/*"],
-  "exclude": [
-    "node_modules",
-    "dist",
-    "scripts/**/__tests__/**/*",
-    "scripts/**/__mocks__/**/*",
-    "scripts/**/__fixtures__/**/*"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
 }

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "scripts",
+    "outDir": "dist/scripts"
+  },
+  "include": ["scripts/**/*", "types/**/*"],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "scripts/**/__tests__/**/*",
+    "scripts/**/__mocks__/**/*",
+    "scripts/**/__fixtures__/**/*"
+  ]
+}

--- a/types/node-shim.d.ts
+++ b/types/node-shim.d.ts
@@ -34,7 +34,13 @@ declare module 'node:path' {
     dirname: (path: string) => string;
     basename: (path: string) => string;
     extname: (path: string) => string;
-    parse: (path: string) => { dir: string; name: string; base: string; ext: string; root: string };
+    parse: (path: string) => {
+      dir: string;
+      name: string;
+      base: string;
+      ext: string;
+      root: string;
+    };
   };
   export default path;
 }

--- a/types/node-shim.d.ts
+++ b/types/node-shim.d.ts
@@ -19,7 +19,7 @@ type BufferEncoding =
   | 'binary'
   | 'hex';
 
-type BinaryLike = string | Buffer;
+type BinaryLike = string | Buffer | ArrayBuffer | ArrayBufferView;
 
 declare const process: {
   cwd(): string;

--- a/types/node-shim.d.ts
+++ b/types/node-shim.d.ts
@@ -31,9 +31,16 @@ type BufferEncoding =
 
 declare module 'node:fs/promises' {
   export function access(path: PathLike, mode?: number): Promise<void>;
-  export function readFile(path: PathLike, encoding: BufferEncoding): Promise<string>;
+  export function readFile(
+    path: PathLike,
+    encoding: BufferEncoding
+  ): Promise<string>;
   export function readFile(path: PathLike): Promise<Buffer>;
-  export function writeFile(path: PathLike, data: string | Buffer, encoding?: BufferEncoding): Promise<void>;
+  export function writeFile(
+    path: PathLike,
+    data: string | Buffer,
+    encoding?: BufferEncoding
+  ): Promise<void>;
   export function mkdir(
     path: PathLike,
     options?: { recursive?: boolean; mode?: number }

--- a/types/node-shim.d.ts
+++ b/types/node-shim.d.ts
@@ -14,12 +14,31 @@ declare interface NodeProcess {
 
 declare const process: NodeProcess;
 
+type Buffer = Uint8Array;
+type PathLike = string;
+type BufferEncoding =
+  | 'ascii'
+  | 'utf8'
+  | 'utf-8'
+  | 'utf16le'
+  | 'ucs2'
+  | 'ucs-2'
+  | 'base64'
+  | 'base64url'
+  | 'latin1'
+  | 'binary'
+  | 'hex';
+
 declare module 'node:fs/promises' {
-  export const access: (...args: any[]) => Promise<any>;
-  export const readFile: (...args: any[]) => Promise<any>;
-  export const writeFile: (...args: any[]) => Promise<any>;
-  export const mkdir: (...args: any[]) => Promise<any>;
-  export const unlink: (...args: any[]) => Promise<any>;
+  export function access(path: PathLike, mode?: number): Promise<void>;
+  export function readFile(path: PathLike, encoding: BufferEncoding): Promise<string>;
+  export function readFile(path: PathLike): Promise<Buffer>;
+  export function writeFile(path: PathLike, data: string | Buffer, encoding?: BufferEncoding): Promise<void>;
+  export function mkdir(
+    path: PathLike,
+    options?: { recursive?: boolean; mode?: number }
+  ): Promise<void>;
+  export function unlink(path: PathLike): Promise<void>;
 }
 
 declare module 'node:fs' {

--- a/types/node-shim.d.ts
+++ b/types/node-shim.d.ts
@@ -1,0 +1,67 @@
+declare namespace NodeJS {
+  interface ErrnoException extends Error {
+    code?: string;
+  }
+}
+
+declare interface NodeProcess {
+  cwd(): string;
+  exit(code?: number): never;
+  exitCode: number | undefined;
+  argv: string[];
+  env: Record<string, string | undefined>;
+}
+
+declare const process: NodeProcess;
+
+declare module 'node:fs/promises' {
+  export const access: (...args: any[]) => Promise<any>;
+  export const readFile: (...args: any[]) => Promise<any>;
+  export const writeFile: (...args: any[]) => Promise<any>;
+  export const mkdir: (...args: any[]) => Promise<any>;
+  export const unlink: (...args: any[]) => Promise<any>;
+}
+
+declare module 'node:fs' {
+  export const constants: Record<string, number>;
+}
+
+declare module 'node:path' {
+  const path: {
+    join: (...segments: string[]) => string;
+    resolve: (...segments: string[]) => string;
+    relative: (from: string, to: string) => string;
+    dirname: (path: string) => string;
+    basename: (path: string) => string;
+    extname: (path: string) => string;
+    parse: (path: string) => { dir: string; name: string; base: string; ext: string; root: string };
+  };
+  export default path;
+}
+
+declare module 'node:os' {
+  const os: {
+    tmpdir: () => string;
+  };
+  export default os;
+}
+
+declare module 'node:crypto' {
+  export const createHash: (...args: any[]) => {
+    update: (...args: any[]) => any;
+    digest: (...args: any[]) => any;
+  };
+  export const randomUUID: () => string;
+}
+
+declare module 'node:child_process' {
+  interface ChildProcess {
+    on(event: 'error', listener: (error: Error) => void): this;
+    on(event: 'close', listener: (code: number | null) => void): this;
+  }
+  export const spawn: (
+    command: string,
+    args: string[],
+    options?: { stdio?: any; env?: Record<string, string | undefined> }
+  ) => ChildProcess;
+}

--- a/types/node-shim.d.ts
+++ b/types/node-shim.d.ts
@@ -19,6 +19,8 @@ type BufferEncoding =
   | 'binary'
   | 'hex';
 
+type BinaryLike = string | Buffer;
+
 declare const process: {
   cwd(): string;
   exit(code?: number): never;
@@ -81,9 +83,9 @@ declare module 'node:os' {
 
 declare module 'node:crypto' {
   interface Hash {
-    update(data: string | ArrayBufferView): Hash;
+    update(data: BinaryLike): Hash;
     digest(): Buffer;
-    digest(encoding: 'hex' | 'base64' | 'base64url'): string;
+    digest(encoding: BufferEncoding): string;
   }
 
   export function createHash(algorithm: string): Hash;


### PR DESCRIPTION
## Summary
- add a TypeScript script to copy CLAUDE.md into AGENTS.md and expose it via yarn sync:agents
- extend the CI workflow to run the sync script and fail when CLAUDE.md and AGENTS.md diverge
- check in AGENTS.md so both guides share the same content

## Testing
- yarn sync:agents

------
https://chatgpt.com/codex/tasks/task_e_68da6f9d9ce4832da927d55d110b155b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Renamed and expanded the canonical Agent Guide with broader AI copilot guidance, repo overview, core commands, translation snapshot, and collaboration tips; added docs describing CI validation for guide synchronization.

* **Chores**
  * Added a local sync command and CI check that enforces guide synchronization with clear failure messages.
  * Updated package scripts, TypeScript build configs, and added Node type shims; tightened some type annotations to improve tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->